### PR TITLE
Refactor: 메인페이지 통신 효율성 증대

### DIFF
--- a/src/components/PostList/index.jsx
+++ b/src/components/PostList/index.jsx
@@ -6,19 +6,13 @@ import PostListNavBar from '../PostListNavBar';
 import PostSkeleton from '../PostSkeleton';
 import { maxWidth1056px, maxWidth1440px, maxWidth1920px, minWidth250px } from '../../styles/media';
 import useAxios from '../../hooks/useAxios';
-import { plusPageNum, resetPageNum } from '../../store/modules/mainnavbar';
-import { useLocation } from 'react-router-dom';
+import { plusPageNum } from '../../store/modules/mainnavbar';
 
 const PostList = () => {
   const dispatch = useDispatch();
-  const location = useLocation();
   const { name, query, pageNum } = useSelector(state => state.mainNavBar);
   const loader = useRef(null);
   const { postData, noMorePosts } = useAxios(query, pageNum, name);
-
-  useEffect(() => {
-    dispatch(resetPageNum());
-  }, [location.pathname]);
 
   const intersectionObserver = useCallback(entries => {
     const target = entries[0];

--- a/src/components/PostListNavBar/PeriodFilter/index.jsx
+++ b/src/components/PostListNavBar/PeriodFilter/index.jsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { MdOutlineArrowDropDown } from 'react-icons/md';
 import { tabStyle } from '../../../styles/postlistnavbar';
-import { setQuery } from '../../../store/modules/mainnavbar';
+import { resetPageNum, setQuery } from '../../../store/modules/mainnavbar';
 
 const PeriodFilter = () => {
   const [isToggle, setIsToggle] = useState(false);
@@ -63,8 +63,9 @@ const PeriodFilter = () => {
                 arr.forEach(filter => (filter.view = false));
                 arr[i].view = true;
                 setFilterList(arr);
-                dispatch(setQuery(filter.query));
                 setFilter(filter.name);
+                dispatch(resetPageNum());
+                dispatch(setQuery(filter.query));
                 setIsToggle(false);
               }}
             >

--- a/src/hooks/useAxios.js
+++ b/src/hooks/useAxios.js
@@ -1,13 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
 import { apiClient } from '../api';
 
-const useAxios = (period, pageNum, name) => {
+const useAxios = (query, pageNum, name) => {
   const [postData, setPostData] = useState([]);
   const [noMorePosts, setNoMorePosts] = useState(false);
 
   const sendQuery = useCallback(async () => {
     try {
-      const { data } = await apiClient.get(`/main?type=${name}&period=${period}&offset=${pageNum}&limit=30`);
+      const { data } = await apiClient.get(`/main?type=${name}&period=${query}&offset=${pageNum}&limit=30`);
       if (data.post.length) {
         if (pageNum === 1) {
           setPostData([]);
@@ -22,11 +22,11 @@ const useAxios = (period, pageNum, name) => {
     } catch (error) {
       console.log('메인페이지 게시글 통신 오류 => ', error);
     }
-  }, [period, pageNum, name]);
+  }, [query, pageNum, name]);
 
   useEffect(() => {
     sendQuery();
-  }, [period, sendQuery, pageNum, name]);
+  }, [query, pageNum, name]);
 
   return { postData, noMorePosts };
 };

--- a/src/pages/Main/index.jsx
+++ b/src/pages/Main/index.jsx
@@ -2,27 +2,28 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import PostList from '../../components/PostList';
-import { setName, setQuery } from '../../store/modules/mainnavbar';
+import { resetPageNum, setName, setQuery } from '../../store/modules/mainnavbar';
 
 const Main = () => {
   const location = useLocation();
+  const pathname = location.pathname;
   const dispatch = useDispatch();
   const { name } = useSelector(state => state.mainNavBar);
 
   useEffect(() => {
-    const path = location.pathname;
-    if (path === '/') {
+    if (pathname === '/') {
       dispatch(setName('trend'));
       dispatch(setQuery('week'));
-    } else if (path === '/recent') {
+    } else if (pathname === '/recent') {
       dispatch(setName('recent'));
       dispatch(setQuery(''));
-    } else if (path === '/follow') {
+    } else if (pathname === '/follow') {
       dispatch(setName('follow'));
       dispatch(setQuery(''));
     }
+    dispatch(resetPageNum());
     return;
-  }, [location]);
+  }, [pathname]);
 
   return name && <PostList />;
 };


### PR DESCRIPTION
… 메인페이지 컴포넌트에서 pathname이 바뀔때만 page number가 1로 바뀌게 변경

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] UI 추가
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정

<br />

## :: 구현 사항 설명

1. 메인페이지 렌더링

- 메인 포스트 리스트 컴포넌트에서 처음 렌더링 될때마다 페이지 넘버를 1로 변경하는 로직을 더 상위 페이지인 메인페이지 컴포넌트에서 pathname이 바뀔때만 page number가 1로 바뀌게 변경
